### PR TITLE
Atmosphere/serialbox test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -759,6 +759,15 @@ endif
 	LIBS += $(NCLIB)
 endif
 
+FCINCLUDES += -I/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/include \
+           -I/glade/derecho/scratch/agopal/serialbox_2.6.2_2/src \
+           -isystem /glade/derecho/scratch/agopal/boost_1_86_0/install/include
+
+SERLIB = libsimple_m_ser.a
+
+#LIBS +=  -L/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread
+LIBS +=  -Wl,-rpath,: /glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib/libSerialboxFortran.a \
+           /glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib/libSerialboxC.a /glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib/libSerialboxCore.a
 
 ifneq "$(PNETCDF)" ""
 ifneq ($(wildcard $(PNETCDF)/lib), )
@@ -857,6 +866,8 @@ ifeq "$(OPENMP_OFFLOAD)" "true"
 	override CPPFLAGS += "-DMPAS_OPENMP_OFFLOAD"
 	LDFLAGS += $(LDFLAGS_GPU)
 endif #OPENMP_OFFLOAD IF
+
+FFLAGS += "-DSERIALIZE"
 
 ifneq (,$(filter-out double single,$(PRECISION)))
 $(error PRECISION should be "", "single", or "double"; received value "$(PRECISION)")

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ nvhpc:   # BUILDTARGET NVIDIA HPC SDK
 	"LDFLAGS_DEBUG = -O0 -g -Mbounds -Ktrap=divz,fp,inv,ovf -traceback" \
 	"FFLAGS_OMP = -mp" \
 	"CFLAGS_OMP = -mp" \
-	"FFLAGS_ACC = -Mnofma -acc -gpu=cc70,cc80 -Minfo=accel" \
+	"FFLAGS_ACC = -Mnofma -acc -gpu=cc70,cc80 -Minfo=accel " \
 	"CFLAGS_ACC =" \
 	"PICFLAG = -fpic" \
 	"BUILD_TARGET = $(@)" \
@@ -761,12 +761,12 @@ endif
 
 FCINCLUDES += -I/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/include \
            -I/glade/derecho/scratch/agopal/serialbox_2.6.2_2/src \
-           -isystem /glade/derecho/scratch/agopal/boost_1_86_0/install/include
+           -isystem /glade/derecho/scratch/agopal/boost_1_86_0/install/include -DSERIALIZE
 
 SERLIB = libsimple_m_ser.a
 
 #LIBS +=  -L/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread
-LIBS +=  -Wl,-rpath,: /glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib/libSerialboxFortran.a \
+LIBS +=  -Wl,-rpath,libsimple_m_ser.a /glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib/libSerialboxFortran.a \
            /glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib/libSerialboxC.a /glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib/libSerialboxCore.a
 
 ifneq "$(PNETCDF)" ""
@@ -867,7 +867,8 @@ ifeq "$(OPENMP_OFFLOAD)" "true"
 	LDFLAGS += $(LDFLAGS_GPU)
 endif #OPENMP_OFFLOAD IF
 
-FFLAGS += "-DSERIALIZE"
+#FFLAGS += " -DSERIALIZE"
+#FFLAGS += " -I/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/include "
 
 ifneq (,$(filter-out double single,$(PRECISION)))
 $(error PRECISION should be "", "single", or "double"; received value "$(PRECISION)")

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ nvhpc:   # BUILDTARGET NVIDIA HPC SDK
 	"LDFLAGS_DEBUG = -O0 -g -Mbounds -Ktrap=divz,fp,inv,ovf -traceback" \
 	"FFLAGS_OMP = -mp" \
 	"CFLAGS_OMP = -mp" \
-	"FFLAGS_ACC = -Mnofma -acc -gpu=cc70,cc80 -Minfo=accel " \
+	"FFLAGS_ACC = -Mnofma -acc -gpu=cc70,cc80 -Minfo=accel" \
 	"CFLAGS_ACC =" \
 	"PICFLAG = -fpic" \
 	"BUILD_TARGET = $(@)" \
@@ -768,7 +768,6 @@ FCINCLUDES += -I$(SERIALBOX_ROOT)/install/include \
 
 SERLIB = libsimple_m_ser.a
 
-#LIBS +=  -L/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread
 LIBS +=  -Wl,-rpath,libsimple_m_ser.a $(SERIALBOX_ROOT)/install/lib/libSerialboxFortran.a \
            $(SERIALBOX_ROOT)/install/lib/libSerialboxC.a $(SERIALBOX_ROOT)/install/lib/libSerialboxCore.a
 
@@ -869,9 +868,6 @@ ifeq "$(OPENMP_OFFLOAD)" "true"
 	override CPPFLAGS += "-DMPAS_OPENMP_OFFLOAD"
 	LDFLAGS += $(LDFLAGS_GPU)
 endif #OPENMP_OFFLOAD IF
-
-#FFLAGS += " -DSERIALIZE"
-#FFLAGS += " -I/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/include "
 
 ifneq (,$(filter-out double single,$(PRECISION)))
 $(error PRECISION should be "", "single", or "double"; received value "$(PRECISION)")

--- a/Makefile
+++ b/Makefile
@@ -759,15 +759,18 @@ endif
 	LIBS += $(NCLIB)
 endif
 
-FCINCLUDES += -I/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/include \
-           -I/glade/derecho/scratch/agopal/serialbox_2.6.2_2/src \
-           -isystem /glade/derecho/scratch/agopal/boost_1_86_0/install/include -DSERIALIZE
+export SERIALBOX_ROOT=/glade/derecho/scratch/agopal/myserialbox
+export BOOST_ROOT=/glade/derecho/scratch/agopal/boost_1_86_0
+
+FCINCLUDES += -I$(SERIALBOX_ROOT)/install/include \
+           -I$(SERIALBOX_ROOT)/src \
+           -isystem $(BOOST_ROOT)/install/include -DSERIALIZE
 
 SERLIB = libsimple_m_ser.a
 
 #LIBS +=  -L/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread
-LIBS +=  -Wl,-rpath,libsimple_m_ser.a /glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib/libSerialboxFortran.a \
-           /glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib/libSerialboxC.a /glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/lib/libSerialboxCore.a
+LIBS +=  -Wl,-rpath,libsimple_m_ser.a $(SERIALBOX_ROOT)/install/lib/libSerialboxFortran.a \
+           $(SERIALBOX_ROOT)/install/lib/libSerialboxC.a $(SERIALBOX_ROOT)/install/lib/libSerialboxCore.a
 
 ifneq "$(PNETCDF)" ""
 ifneq ($(wildcard $(PNETCDF)/lib), )

--- a/src/core_atmosphere/dynamics/Makefile
+++ b/src/core_atmosphere/dynamics/Makefile
@@ -38,7 +38,7 @@ clean:
 # 	/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/python/pp_ser/pp_ser.py $< -o $@
 
 %_ser.F: %.F
-	/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/python/pp_ser/pp_ser.py $< -o $@	
+	$(SERIALBOX_ROOT)/install/python/pp_ser/pp_ser.py $< -o $@	
 
 # Rule to create the static library
 # $(SERLIB): m_ser_o.o

--- a/src/core_atmosphere/dynamics/Makefile
+++ b/src/core_atmosphere/dynamics/Makefile
@@ -22,7 +22,7 @@ SERLIB = libsimple_m_ser.a
 
 all: $(OBJS) $(SERLIB)
 
-mpas_atm_time_integration.o: mpas_atm_boundaries.o mpas_atm_iau.o
+mpas_atm_time_integration_ser.o: mpas_atm_boundaries.o mpas_atm_iau.o
 
 mpas_atm_boundaries.o:
 

--- a/src/core_atmosphere/dynamics/Makefile
+++ b/src/core_atmosphere/dynamics/Makefile
@@ -1,4 +1,5 @@
 .SUFFIXES: .F .o
+.SECONDARY: $(%_ser.F)
 
 # Generated source files
 #GEN_SRC = m_ser_o.F
@@ -6,9 +7,15 @@
 #OBJS = $(GEN_SRC:.F=.o) mpas_atm_time_integration.o \
 #       mpas_atm_boundaries.o
 
-GEN_SRC = m_ser_o.F mpas_atm_time_integration_o.F
+GEN_SRC = m_ser_ser.F mpas_atm_time_integration_ser.F
+#GEN_SRC = m_ser_ser.F
 
+#OBJS = $(GEN_SRC:.F=.o) mpas_atm_time_integration.o mpas_atm_boundaries.o
 OBJS = $(GEN_SRC:.F=.o) mpas_atm_boundaries.o
+#OBJS = $(patsubst %.F, %.F.o, $(filter %_o.F, $(GEN_SRC))) mpas_atm_boundaries.o
+#OBJS = $(patsubst %.F, %.F.o, $(filter %_o.F, $(GEN_SRC))) mpas_atm_time_integration.o mpas_atm_boundaries.o
+$(info ************  OBJSSS ************)
+$(info ************  ${OBJS} ************)
 
 # Static library
 SERLIB = libsimple_m_ser.a
@@ -21,20 +28,24 @@ mpas_atm_boundaries.o:
 
 
 clean:
-	$(RM) *.o *.mod *.F
+	$(RM) *.o *.mod *.f90
 	@# Certain systems with intel compilers generate *.i files
 	@# This removes them during the clean process
 	$(RM) *.i
 
 # Rule to generate m_ser_o.F90 from m_ser.F90
-#m_ser_o.F: m_ser.F
-#	/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/python/pp_ser/pp_ser.py $< -o $@
+# m_ser_o.F: m_ser.F
+# 	/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/python/pp_ser/pp_ser.py $< -o $@
 
-%_o.F: %.F
+%_ser.F: %.F
 	/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/python/pp_ser/pp_ser.py $< -o $@	
 
 # Rule to create the static library
-$(SERLIB): m_ser_o.o
+# $(SERLIB): m_ser_o.o
+# 	/usr/bin/ar qc $@ $^
+# 	/usr/bin/ranlib $@
+
+$(SERLIB): m_ser_ser.o
 	/usr/bin/ar qc $@ $^
 	/usr/bin/ranlib $@
 
@@ -43,7 +54,13 @@ $(SERLIB): m_ser_o.o
 	$(RM) $@ $*.mod
 ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(PHYSICS) $(CPPINCLUDES) $< > $*.f90
-	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES)  -I.. -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../physics/physics_mmm -I../../external/esmf_time_f90
+	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I.. -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../physics/physics_mmm -I../../external/esmf_time_f90
+	$(info ************  first ************)
 else
 	$(FC) $(CPPFLAGS) $(PHYSICS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I.. -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../physics/physics_mmm -I../../external/esmf_time_f90
+	$(info ************  second ************)
 endif
+
+%_ser.o: %_ser.F
+	$(FC) $(CPPFLAGS) $(PHYSICS) $(FFLAGS) -c $< $(CPPINCLUDES) $(FCINCLUDES) -I.. -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../physics/physics_mmm -I../../external/esmf_time_f90
+	$(info ************  third ************)

--- a/src/core_atmosphere/dynamics/Makefile
+++ b/src/core_atmosphere/dynamics/Makefile
@@ -1,10 +1,7 @@
 .SUFFIXES: .F .o
 .SECONDARY: $(%_ser.F)
 
-# Generated source files
-#GEN_SRC = m_ser_o.F
-
-#OBJS = $(GEN_SRC:.F=.o) mpas_atm_time_integration.o \
+#OBJS = mpas_atm_time_integration.o \
 #       mpas_atm_boundaries.o
 
 GEN_SRC = m_ser_ser.F mpas_atm_time_integration_ser.F
@@ -12,10 +9,7 @@ GEN_SRC = m_ser_ser.F mpas_atm_time_integration_ser.F
 
 #OBJS = $(GEN_SRC:.F=.o) mpas_atm_time_integration.o mpas_atm_boundaries.o
 OBJS = $(GEN_SRC:.F=.o) mpas_atm_boundaries.o
-#OBJS = $(patsubst %.F, %.F.o, $(filter %_o.F, $(GEN_SRC))) mpas_atm_boundaries.o
-#OBJS = $(patsubst %.F, %.F.o, $(filter %_o.F, $(GEN_SRC))) mpas_atm_time_integration.o mpas_atm_boundaries.o
-$(info ************  OBJSSS ************)
-$(info ************  ${OBJS} ************)
+
 
 # Static library
 SERLIB = libsimple_m_ser.a
@@ -33,18 +27,11 @@ clean:
 	@# This removes them during the clean process
 	$(RM) *.i
 
-# Rule to generate m_ser_o.F90 from m_ser.F90
-# m_ser_o.F: m_ser.F
-# 	/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/python/pp_ser/pp_ser.py $< -o $@
-
+# Rule to generate m_ser_ser.F90 from m_ser.F90
 %_ser.F: %.F
 	$(SERIALBOX_ROOT)/install/python/pp_ser/pp_ser.py $< -o $@	
 
 # Rule to create the static library
-# $(SERLIB): m_ser_o.o
-# 	/usr/bin/ar qc $@ $^
-# 	/usr/bin/ranlib $@
-
 $(SERLIB): m_ser_ser.o
 	/usr/bin/ar qc $@ $^
 	/usr/bin/ranlib $@
@@ -55,12 +42,9 @@ $(SERLIB): m_ser_ser.o
 ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(PHYSICS) $(CPPINCLUDES) $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I.. -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../physics/physics_mmm -I../../external/esmf_time_f90
-	$(info ************  first ************)
 else
 	$(FC) $(CPPFLAGS) $(PHYSICS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I.. -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../physics/physics_mmm -I../../external/esmf_time_f90
-	$(info ************  second ************)
 endif
 
 %_ser.o: %_ser.F
 	$(FC) $(CPPFLAGS) $(PHYSICS) $(FFLAGS) -c $< $(CPPINCLUDES) $(FCINCLUDES) -I.. -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../physics/physics_mmm -I../../external/esmf_time_f90
-	$(info ************  third ************)

--- a/src/core_atmosphere/dynamics/Makefile
+++ b/src/core_atmosphere/dynamics/Makefile
@@ -1,9 +1,19 @@
 .SUFFIXES: .F .o
 
-OBJS = mpas_atm_time_integration.o \
-       mpas_atm_boundaries.o
+# Generated source files
+#GEN_SRC = m_ser_o.F
 
-all: $(OBJS)
+#OBJS = $(GEN_SRC:.F=.o) mpas_atm_time_integration.o \
+#       mpas_atm_boundaries.o
+
+GEN_SRC = m_ser_o.F mpas_atm_time_integration_o.F
+
+OBJS = $(GEN_SRC:.F=.o) mpas_atm_boundaries.o
+
+# Static library
+SERLIB = libsimple_m_ser.a
+
+all: $(OBJS) $(SERLIB)
 
 mpas_atm_time_integration.o: mpas_atm_boundaries.o mpas_atm_iau.o
 
@@ -11,16 +21,29 @@ mpas_atm_boundaries.o:
 
 
 clean:
-	$(RM) *.o *.mod *.f90
+	$(RM) *.o *.mod *.F
 	@# Certain systems with intel compilers generate *.i files
 	@# This removes them during the clean process
 	$(RM) *.i
+
+# Rule to generate m_ser_o.F90 from m_ser.F90
+#m_ser_o.F: m_ser.F
+#	/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/python/pp_ser/pp_ser.py $< -o $@
+
+%_o.F: %.F
+	/glade/derecho/scratch/agopal/serialbox_2.6.2_2/install/python/pp_ser/pp_ser.py $< -o $@	
+
+# Rule to create the static library
+$(SERLIB): m_ser_o.o
+	/usr/bin/ar qc $@ $^
+	/usr/bin/ranlib $@
+
 
 .F.o:
 	$(RM) $@ $*.mod
 ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(PHYSICS) $(CPPINCLUDES) $< > $*.f90
-	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I.. -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../physics/physics_mmm -I../../external/esmf_time_f90
+	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES)  -I.. -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../physics/physics_mmm -I../../external/esmf_time_f90
 else
 	$(FC) $(CPPFLAGS) $(PHYSICS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I.. -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../physics/physics_mmm -I../../external/esmf_time_f90
 endif

--- a/src/core_atmosphere/dynamics/m_ser.F
+++ b/src/core_atmosphere/dynamics/m_ser.F
@@ -1,0 +1,223 @@
+!----------------------------------------------------------*- Fortran -*-----
+!
+!                              S E R I A L B O X
+!
+! This file is distributed under terms of BSD license. 
+! See LICENSE.txt for more information.
+!
+!------------------------------------------------------------------------------
+
+MODULE m_ser
+    use mpas_kind_types
+    use mpas_log, only : mpas_log_write
+    use mpas_derived_types, only : MPAS_LOG_WARN, MPAS_LOG_CRIT
+
+    IMPLICIT NONE
+
+    PUBLIC :: serialize, deserialize, ser_array, ser_init
+
+    INTERFACE ser_array
+    MODULE PROCEDURE ser_array_2d
+    MODULE PROCEDURE ser_array_3d
+    END INTERFACE ser_array
+  
+    CONTAINS
+
+    
+
+  
+    SUBROUTINE serialize(a)
+      IMPLICIT NONE
+      REAL(KIND=8), DIMENSION(:,:,:) :: a
+  
+      !$ser init directory='.' prefix='SerialboxTest'
+      !$ser savepoint sp1
+      !$ser mode write
+      !$ser data ser_a=a
+  
+    END SUBROUTINE serialize
+  
+    SUBROUTINE deserialize(a)
+      IMPLICIT NONE
+      REAL(KIND=8), DIMENSION(:,:,:) :: a
+  
+      !$ser init directory='.' prefix='SerialboxTest-output' prefix_ref='SerialboxTest'
+      !$ser savepoint sp1
+      !$ser mode read
+      !$ser data ser_a=a
+      !$ser mode write
+      !$ser data ser_a=a
+  
+    END SUBROUTINE deserialize
+  
+    SUBROUTINE deserialize_with_perturb(a)
+      IMPLICIT NONE
+      REAL(KIND=8), DIMENSION(:,:,:) :: a
+      REAL(KIND=8) :: rprecision
+      rprecision = 10.0**(-PRECISION(1.0))
+  
+      !$ser init directory='.' prefix='SerialboxTest-output' prefix_ref='SerialboxTest' rprecision=rprecision rperturb=1.0e-5_8
+      !$ser savepoint sp1
+      !$ser mode read-perturb
+      !$ser data ser_a=a
+  
+    END SUBROUTINE deserialize_with_perturb
+
+
+    SUBROUTINE ser_init(suffix)
+      IMPLICIT NONE
+      CHARACTER(LEN=*), INTENT(IN) :: suffix
+      REAL(KIND=RKIND) :: rprecision
+      rprecision = 10.0**(-PRECISION(1.0))
+  
+  !    ! $ser verbatim    IF (linitialize) THEN
+  
+  !#if defined( SERIALIZE_CREATE_REFERENCE )
+      !$ser init directory='./ser_data' &
+      !$ser&     prefix='reference_'//TRIM(suffix) &
+      !$ser&     mpi_rank=0
+  ! #else
+  !     !$ser init directory='./ser_data' &
+  !     !$ser&     prefix='current_'//TRIM(suffix) &
+  !     !$ser&     prefix_ref='reference_'//TRIM(suffix) &
+  !     !$ser&     mpi_rank=0
+  ! #endif
+  
+  !    !$ser verbatim     linitialize = .FALSE.
+  !    !$ser verbatim     END IF
+  
+    END SUBROUTINE ser_init
+ 
+  
+
+    SUBROUTINE ser_array_d_3d(name, ptr, mode)
+      CHARACTER(len=*), INTENT(IN) :: name
+      REAL(RKIND), TARGET, INTENT(INOUT) :: ptr(:,:,:)
+      REAL(RKIND), DIMENSION(size(ptr, 1), size(ptr, 2), size(ptr, 3)) :: ptr_copy
+      INTEGER, INTENT(IN) :: mode
+      INTEGER :: i, j, k
+      CHARACTER(len=3) :: c="   "
+    
+      SELECT CASE (mode)
+        CASE(0) ! write
+          !$ACC PARALLEL LOOP GANG VECTOR COLLAPSE(3) COPYOUT(ptr_copy) ASYNC(1) PRESENT(ptr)
+          DO k = 1, size(ptr, 3)
+            DO j = 1, size(ptr, 2)
+              DO i = 1, size(ptr, 1)
+                ptr_copy(i, j, k) = ptr(i, j, k)
+              ENDDO
+            ENDDO
+          ENDDO
+          !$ACC END PARALLEL
+          !$ACC WAIT(1)
+          CALL fs_write_field(ppser_serializer, ppser_savepoint, TRIM(name//c), ptr_copy(:,:,:))
+        CASE(1) ! read
+          CALL fs_read_field(ppser_serializer_ref, ppser_savepoint, TRIM(name//c), ptr_copy(:,:,:))
+          !$ACC PARALLEL LOOP GANG VECTOR COLLAPSE(3) COPYIN(ptr_copy) ASYNC(1) PRESENT(ptr)
+          DO k = 1, size(ptr, 3)
+            DO j = 1, size(ptr, 2)
+              DO i = 1, size(ptr, 1)
+                ptr(i, j, k) = ptr_copy(i, j, k)
+              ENDDO
+            ENDDO
+          ENDDO
+          !$ACC END PARALLEL
+          !$ACC WAIT(1)
+        CASE(2) ! read perturb
+          CALL fs_read_field(ppser_serializer_ref, ppser_savepoint, TRIM(name//c), ptr_copy(:,:,:), ppser_zrperturb)
+          !$ACC PARALLEL LOOP GANG VECTOR COLLAPSE(3) COPYIN(ptr_copy) ASYNC(1) PRESENT(ptr)
+          DO k = 1, size(ptr, 3)
+            DO j = 1, size(ptr, 2)
+              DO i = 1, size(ptr, 1)
+                ptr(i, j, k) = ptr_copy(i, j, k)
+              ENDDO
+            ENDDO
+          ENDDO
+          !$ACC END PARALLEL
+          !$ACC WAIT(1)
+        CASE(3) ! compare
+          !CALL compare(TRIM(name//c), ptr(:,:,:), o%lopenacc, o%abs_threshold, o%rel_threshold)
+          call mpas_log_write('Error: compare mode not defined.', messageType=MPAS_LOG_CRIT)
+
+        CASE DEFAULT
+          call mpas_log_write('Error: ser mode not defined.', messageType=MPAS_LOG_CRIT)
+      END SELECT
+  
+    END SUBROUTINE ser_array_d_3d
+
+    SUBROUTINE ser_array_2d(name, ptr, ser_mode)
+    CHARACTER(len=*), INTENT(IN) :: name
+    REAL(RKIND), TARGET, INTENT(INOUT) :: ptr(:,:)
+    REAL(RKIND), DIMENSION(size(ptr, 1), size(ptr, 2)) :: ptr_copy
+    INTEGER, INTENT(IN) :: ser_mode
+    INTEGER :: i, j
+    CHARACTER(len=3) :: c="   "
+
+    SELECT CASE (ser_mode)
+        CASE(0) ! write
+            !$ACC PARALLEL LOOP GANG VECTOR COLLAPSE(2) COPYOUT(ptr_copy) ASYNC(1) PRESENT(ptr)
+            DO j = 1, size(ptr, 2)
+                DO i = 1, size(ptr, 1)
+                    ptr_copy(i, j) = ptr(i, j)
+                ENDDO
+            ENDDO
+            !$ACC END PARALLEL
+            !$ACC WAIT(1)
+            CALL fs_write_field(ppser_serializer, ppser_savepoint, TRIM(name//c), ptr_copy(:,:))
+        CASE(1) ! read
+            CALL fs_read_field(ppser_serializer_ref, ppser_savepoint, TRIM(name//c), ptr_copy(:,:))
+            !$ACC PARALLEL LOOP GANG VECTOR COLLAPSE(2) COPYIN(ptr_copy) ASYNC(1) PRESENT(ptr)
+            DO j = 1, size(ptr, 2)
+                DO i = 1, size(ptr, 1)
+                    ptr(i, j) = ptr_copy(i, j)
+                ENDDO
+            ENDDO
+            !$ACC END PARALLEL
+            !$ACC WAIT(1)
+        CASE DEFAULT
+            call mpas_log_write('Error: ser mode not defined.', messageType=MPAS_LOG_CRIT)
+    END SELECT
+  
+  END SUBROUTINE ser_array_2d
+
+    SUBROUTINE ser_array_3d(name, ptr, ser_mode)
+      CHARACTER(len=*), INTENT(IN) :: name
+      REAL(RKIND), TARGET, INTENT(INOUT) :: ptr(:,:,:)
+      REAL(RKIND), DIMENSION(size(ptr, 1), size(ptr, 2), size(ptr, 3)) :: ptr_copy
+      INTEGER, INTENT(IN) :: ser_mode
+      INTEGER :: i, j, k
+      CHARACTER(len=3) :: c="   "
+    
+      SELECT CASE (ser_mode)
+        CASE(0) ! write
+          !$ACC PARALLEL LOOP GANG VECTOR COLLAPSE(3) COPYOUT(ptr_copy) ASYNC(1) PRESENT(ptr)
+          DO k = 1, size(ptr, 3)
+            DO j = 1, size(ptr, 2)
+              DO i = 1, size(ptr, 1)
+                ptr_copy(i, j, k) = ptr(i, j, k)
+              ENDDO
+            ENDDO
+          ENDDO
+          !$ACC END PARALLEL
+          !$ACC WAIT(1)
+          CALL fs_write_field(ppser_serializer, ppser_savepoint, TRIM(name//c), ptr_copy(:,:,:))
+        CASE(1) ! read
+          CALL fs_read_field(ppser_serializer_ref, ppser_savepoint, TRIM(name//c), ptr_copy(:,:,:))
+          !$ACC PARALLEL LOOP GANG VECTOR COLLAPSE(3) COPYIN(ptr_copy) ASYNC(1) PRESENT(ptr)
+          DO k = 1, size(ptr, 3)
+            DO j = 1, size(ptr, 2)
+              DO i = 1, size(ptr, 1)
+                ptr(i, j, k) = ptr_copy(i, j, k)
+              ENDDO
+            ENDDO
+          ENDDO
+          !$ACC END PARALLEL
+          !$ACC WAIT(1)
+        CASE DEFAULT
+          call mpas_log_write('Error: ser mode not defined.', messageType=MPAS_LOG_CRIT)
+      END SELECT
+  
+    END SUBROUTINE ser_array_3d
+  
+
+  END MODULE m_ser  

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -481,10 +481,13 @@ module atm_time_integration
       call mpas_pool_get_config(block % configs, 'config_apply_lbcs', config_apply_lbcs)
 
       call mpas_get_time(nowTime, dateTimeString=xtime_new)
-      savepoint_name='minee'
-      CALL ser_init('init')
-      call fs_create_savepoint(TRIM(savepoint_name), ppser_savepoint)
-      call fs_add_savepoint_metainfo(ppser_savepoint, 'datetime', TRIM(xtime_new))
+      !$ser init directory='./ser_data' prefix='mpas_dycore'
+      !$ser savepoint atm_srk3 datetime=xtime_new
+      
+      ! savepoint_name='minee'
+      ! CALL ser_init('init')
+      ! call fs_create_savepoint(TRIM(savepoint_name), ppser_savepoint)
+      ! call fs_add_savepoint_metainfo(ppser_savepoint, 'datetime', TRIM(xtime_new))
       if (trim(config_time_integration) == 'SRK3') then
          call atm_srk3(domain, dt, itimestep, exchange_halo_group)
       else
@@ -698,6 +701,13 @@ module atm_time_integration
       tend_rho_physics(:,nCells+1) = 0.0_RKIND
       call mpas_pool_get_array(tend_physics, 'tend_ru_physics', tend_ru_physics)
       tend_ru_physics(:,nEdges+1) = 0.0_RKIND
+
+
+
+      ! !$ser init directory='./ser_data' prefix='mpas_dycore'
+      ! !$ser savepoint atm_srk3 date=date rk_step=rk_step
+      ! !$ser mode write
+      ! !$ser accdata alpha_tri=alpha_tri
 
       !
       ! Initialize RK weights
@@ -1966,10 +1976,10 @@ module atm_time_integration
       !!$acc enter data create(alpha_tri)
       !CALL ser_array('alpha_tri', alpha_tri, 0)
 
-      !$ser init directory='.' prefix='SerialboxTest'
-      !$ser savepoint sp1
-      !$ser mode write
-      !$ser accdata alpha_tri=alpha_tri
+      ! !$ser init directory='.' prefix='SerialboxTest'
+      ! !$ser savepoint sp1
+      ! !$ser mode write
+      ! !$ser accdata alpha_tri=alpha_tri
 ! MGD bad to have all threads setting this variable?
       do k=1,nVertLevels
          cofrz(k) = dtseps*rdzw(k)
@@ -2962,6 +2972,12 @@ module atm_time_integration
             end do
          end do
          !$acc end parallel
+         ! !$ser spinfo rk_step=rk_step
+         !$ser mode write
+         !$ser accdata rtheta_p=rtheta_p
+         !$ser accdata theta_m=theta_m
+         !$ser accdata exner=exner
+         !$ser accdata pressure_p=pressure_p
       else
          !$acc parallel
          !$acc loop collapse(2)
@@ -3293,7 +3309,7 @@ module atm_time_integration
       !$acc enter data copyin(uhAvg, scalar_new)
       MPAS_ACC_TIMER_STOP('atm_advance_scalars [ACC_data_xfer]')
 
-      CALL ser_array('scalar_new', scalar_new, 0)
+      !CALL ser_array('scalar_new', scalar_new, 0)
       !$acc parallel async
       !$acc loop gang worker private(scalar_weight2, ica)
       do iEdge=edgeStart,edgeEnd

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -2765,18 +2765,24 @@ module atm_time_integration
 
       ! Avoid FP errors caused by a potential division by zero below by
       ! initializing the "garbage cell" of rho_zz to a non-zero value
+      !$acc parallel
+      !$acc loop gang vector
       do k=1,nVertLevels
          rho_zz(k,nCells+1) = 1.0
       end do
+      !$acc end parallel
 
       ! compute new density everywhere so we can compute u from ru.
       ! we will also need it to compute theta_m below
 
       invNs = 1 / real(ns,RKIND)
 
+      !$acc parallel
+      !$acc loop gang worker
       do iCell=cellStart,cellEnd
 
 !DIR$ IVDEP
+         !$acc loop vector
          do k = 1, nVertLevels
             rho_p(k,iCell) = rho_p_save(k,iCell) + rho_pp(k,iCell)
 
@@ -2786,6 +2792,7 @@ module atm_time_integration
          w(1,iCell) = 0.0
 
 !DIR$ IVDEP
+         !$acc loop vector
          do k = 2, nVertLevels
             wwAvg(k,iCell) = rw_save(k,iCell) + (wwAvg(k,iCell) * invNs)
             rw(k,iCell) = rw_save(k,iCell) + rw_p(k,iCell)
@@ -2797,8 +2804,11 @@ module atm_time_integration
 
          w(nVertLevels+1,iCell) = 0.0
       end do
+      !$acc end parallel
 
       if (rk_step == 3) then
+         !$acc parallel
+         !$acc loop collapse(2)
          do iCell=cellStart,cellEnd
 !DIR$ IVDEP
             do k = 1, nVertLevels
@@ -2811,7 +2821,10 @@ module atm_time_integration
                                                           * (exner(k,iCell)-exner_base(k,iCell)))
             end do
          end do
+         !$acc end parallel
       else
+         !$acc parallel
+         !$acc loop collapse(2)
          do iCell=cellStart,cellEnd
 !DIR$ IVDEP
             do k = 1, nVertLevels
@@ -2819,6 +2832,7 @@ module atm_time_integration
                theta_m(k,iCell) = (rtheta_p(k,iCell) + rtheta_base(k,iCell))/rho_zz(k,iCell)
             end do
          end do
+         !$acc end parallel
       end if
 
       ! recover time-averaged ruAvg on all edges of owned cells (for upcoming scalar transport).
@@ -2827,21 +2841,27 @@ module atm_time_integration
 
 !$OMP BARRIER
 
+      !$acc parallel
+      !$acc loop gang worker
       do iEdge=edgeStart,edgeEnd
 
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
 
 !DIR$ IVDEP
+         !$acc loop vector
          do k = 1, nVertLevels
             ruAvg(k,iEdge) = ru_save(k,iEdge) + (ruAvg(k,iEdge) * invNs)
             ru(k,iEdge) = ru_save(k,iEdge) + ru_p(k,iEdge)
             u(k,iEdge) = 2.*ru(k,iEdge)/(rho_zz(k,cell1)+rho_zz(k,cell2))
          end do
       end do
+      !$acc end parallel
 
 !$OMP BARRIER
 
+      !$acc parallel
+      !$acc loop gang worker
       do iCell=cellStart,cellEnd
 
          !  finish recovering w from (rho*omega)_p.  as when we formed (rho*omega)_p from u and w, we need
@@ -2850,6 +2870,7 @@ module atm_time_integration
 
          if (bdyMaskCell(iCell) <= nRelaxZone) then  ! addition for regional_MPAS, no spec zone update
 
+            !$acc loop seq
             do i=1,nEdgesOnCell(iCell)
                iEdge=edgesOnCell(i,iCell)
 
@@ -2858,6 +2879,7 @@ module atm_time_integration
                                       (zb_cell(1,i,iCell) + sign(1.0_RKIND,flux)*zb3_cell(1,i,iCell))*flux
 
 !DIR$ IVDEP
+               !$acc loop vector
                do k = 2, nVertLevels
                   flux = (fzm(k)*ru(k,iEdge)+fzp(k)*ru(k-1,iEdge))
                   w(k,iCell) = w(k,iCell) + edgesOnCell_sign(i,iCell) * &
@@ -2870,6 +2892,7 @@ module atm_time_integration
 
 
             !DIR$ IVDEP
+            !$acc loop vector
             do k = 2, nVertLevels
               w(k,iCell) = w(k,iCell)/(fzm(k)*rho_zz(k,iCell)+fzp(k)*rho_zz(k-1,iCell))
             end do
@@ -2877,6 +2900,7 @@ module atm_time_integration
          end if ! addition for regional_MPAS, no spec zone update
 
       end do
+      !$acc end parallel
 
    end subroutine atm_recover_large_step_variables_work
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -17,6 +17,7 @@
 module atm_time_integration
    USE m_ser, ONLY: ser_init, ser_array
    USE m_ser_mpas_cmp, ONLY: mpas_compare
+   USE mo_ser_common, ONLY: compare
    USE m_ser_mpas, ONLY: mpas_set_serializer, mpas_set_savepoint
    USE m_serialize, ONLY: fs_add_savepoint_metainfo, fs_read_field, fs_create_savepoint, fs_write_field
    USE utils_ppser, ONLY: ppser_set_mode, ppser_initialize, ppser_get_mode, ppser_savepoint, &

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1907,8 +1907,13 @@ module atm_time_integration
       ! END SELECT
 
       !CALL ser_array_d_3d('vara', scalars, 0)
-      !$acc enter data create(alpha_tri)
+      !!$acc enter data create(alpha_tri)
       !CALL ser_array('alpha_tri', alpha_tri, 0)
+
+      !$ser init directory='.' prefix='SerialboxTest'
+      !$ser savepoint sp1
+      !$ser mode write
+      !$ser accdata alpha_tri=alpha_tri
 ! MGD bad to have all threads setting this variable?
       do k=1,nVertLevels
          cofrz(k) = dtseps*rdzw(k)
@@ -1970,9 +1975,9 @@ module atm_time_integration
          end do
 
       end do ! loop over cells
-      !$acc update device(alpha_tri)
-      CALL ser_array('alpha_tri', alpha_tri, 0)
-      !$acc exit data delete(alpha_tri)
+      !!$acc update device(alpha_tri)
+      !CALL ser_array('alpha_tri', alpha_tri, 0)
+      !!$acc exit data delete(alpha_tri)
 
    end subroutine atm_compute_vert_imp_coefs_work
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -212,6 +212,13 @@ module atm_time_integration
       real (kind=RKIND), dimension(:), pointer :: invAreaCell
       integer, dimension(:), pointer :: bdyMaskCell
       integer, dimension(:), pointer :: bdyMaskEdge
+      real (kind=RKIND), dimension(:,:), pointer :: zz
+      real (kind=RKIND), dimension(:,:,:), pointer :: zb
+      real (kind=RKIND), dimension(:,:,:), pointer :: zb3
+      real (kind=RKIND), dimension(:,:,:), pointer :: zb_cell
+      real (kind=RKIND), dimension(:,:,:), pointer :: zb3_cell
+      real (kind=RKIND), dimension(:), pointer :: fzm
+      real (kind=RKIND), dimension(:), pointer :: fzp
 #endif
 
 
@@ -271,6 +278,27 @@ module atm_time_integration
 
       call mpas_pool_get_array(mesh, 'bdyMaskEdge', bdyMaskEdge)
       !$acc enter data copyin(bdyMaskEdge)
+
+      call mpas_pool_get_array(mesh, 'zz', zz)
+      !$acc enter data copyin(zz)
+
+      call mpas_pool_get_array(mesh, 'zb', zb)
+      !$acc enter data copyin(zb)
+
+      call mpas_pool_get_array(mesh, 'zb3', zb3)
+      !$acc enter data copyin(zb3)
+
+      call mpas_pool_get_array(mesh, 'zb_cell', zb_cell)
+      !$acc enter data copyin(zb_cell)
+
+      call mpas_pool_get_array(mesh, 'zb3_cell', zb3_cell)
+      !$acc enter data copyin(zb3_cell)
+
+      call mpas_pool_get_array(mesh, 'fzm', fzm)
+      !$acc enter data copyin(fzm)
+
+      call mpas_pool_get_array(mesh, 'fzp', fzp)
+      !$acc enter data copyin(fzp)
 #endif
 
    end subroutine mpas_atm_dynamics_init
@@ -319,6 +347,13 @@ module atm_time_integration
       real (kind=RKIND), dimension(:), pointer :: invAreaCell
       integer, dimension(:), pointer :: bdyMaskCell
       integer, dimension(:), pointer :: bdyMaskEdge
+      real (kind=RKIND), dimension(:,:), pointer :: zz
+      real (kind=RKIND), dimension(:,:,:), pointer :: zb
+      real (kind=RKIND), dimension(:,:,:), pointer :: zb3
+      real (kind=RKIND), dimension(:,:,:), pointer :: zb_cell
+      real (kind=RKIND), dimension(:,:,:), pointer :: zb3_cell
+      real (kind=RKIND), dimension(:), pointer :: fzm
+      real (kind=RKIND), dimension(:), pointer :: fzp
 #endif
 
 
@@ -378,6 +413,27 @@ module atm_time_integration
 
       call mpas_pool_get_array(mesh, 'bdyMaskEdge', bdyMaskEdge)
       !$acc exit data delete(bdyMaskEdge)
+
+      call mpas_pool_get_array(mesh, 'zz', zz)
+      !$acc exit data delete(zz)
+
+      call mpas_pool_get_array(mesh, 'zb', zb)
+      !$acc exit data delete(zb)
+
+      call mpas_pool_get_array(mesh, 'zb3', zb3)
+      !$acc exit data delete(zb3)
+
+      call mpas_pool_get_array(mesh, 'zb_cell', zb_cell)
+      !$acc exit data delete(zb_cell)
+
+      call mpas_pool_get_array(mesh, 'zb3_cell', zb3_cell)
+      !$acc exit data delete(zb3_cell)
+
+      call mpas_pool_get_array(mesh, 'fzm', fzm)
+      !$acc exit data delete(fzm)
+
+      call mpas_pool_get_array(mesh, 'fzp', fzp)
+      !$acc exit data delete(fzp)
 #endif
 
    end subroutine mpas_atm_dynamics_finalize

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -2815,6 +2815,18 @@ module atm_time_integration
       integer :: i, iCell, iEdge, k, cell1, cell2
       real (kind=RKIND) :: invNs, rcv, p0, flux
 
+      MPAS_ACC_TIMER_START('atm_recover_large_step_variables [ACC_data_xfer]')
+      !$acc enter data copyin(rho_p_save,rho_pp,rho_base,rw_save,rw_p, &
+      !$acc                   rtheta_p_save,rtheta_pp,rtheta_base, &
+      !$acc                   ru_save,ru_p) &
+      !$acc            create(rho_zz,rho_p,rw,w,rtheta_p,theta_m, &
+      !$acc                   ru,u) &
+      !$acc            copyin(wwAvg,ruAvg)
+      if (rk_step == 3) then
+         !$acc enter data copyin(rt_diabatic_tend,exner_base) &
+         !$acc            create(exner,pressure_p)
+      end if
+      MPAS_ACC_TIMER_STOP('atm_recover_large_step_variables [ACC_data_xfer]')
 
       rcv = rgas/(cp-rgas)
       p0 = 1.0e+05  ! this should come from somewhere else...
@@ -2957,6 +2969,19 @@ module atm_time_integration
 
       end do
       !$acc end parallel
+
+      MPAS_ACC_TIMER_START('atm_recover_large_step_variables [ACC_data_xfer]')
+      !$acc exit data delete(rho_p_save,rho_pp,rho_base,rw_save,rw_p, &
+      !$acc                   rtheta_p_save,rtheta_pp,rtheta_base, &
+      !$acc                   ru_save,ru_p) &
+      !$acc            copyout(rho_zz,rho_p,rw,w,rtheta_p,theta_m, &
+      !$acc                   ru,u) &
+      !$acc            copyout(wwAvg,ruAvg)
+      if (rk_step == 3) then
+         !$acc exit data delete(rt_diabatic_tend,exner_base) &
+         !$acc            copyout(exner,pressure_p)
+      end if
+      MPAS_ACC_TIMER_STOP('atm_recover_large_step_variables [ACC_data_xfer]')
 
    end subroutine atm_recover_large_step_variables_work
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -15,7 +15,12 @@
 #endif
 
 module atm_time_integration
-
+   USE m_ser, ONLY: ser_init, ser_array
+   USE m_serialize, ONLY: fs_add_savepoint_metainfo, fs_read_field, fs_create_savepoint, fs_write_field
+   USE utils_ppser, ONLY: ppser_set_mode, ppser_initialize, ppser_get_mode, ppser_savepoint, &
+       ppser_serializer, ppser_serializer_ref, ppser_intlength, ppser_reallength, &
+       ppser_realtype, ppser_zrperturb
+   use mpas_timekeeping
    use mpas_derived_types
    use mpas_pool_routines
    use mpas_kind_types
@@ -410,7 +415,8 @@ module atm_time_integration
       real (kind=RKIND) :: Time_new
       type (mpas_pool_type), pointer :: state
       character (len=StrKIND), pointer :: config_time_integration
-
+      character(len=StrKIND) :: timeStamp
+      character(len=StrKIND) :: savepoint_name
 
       clock => domain % clock
       block => domain % blocklist
@@ -418,6 +424,11 @@ module atm_time_integration
       call mpas_pool_get_config(block % configs, 'config_time_integration', config_time_integration)
       call mpas_pool_get_config(block % configs, 'config_apply_lbcs', config_apply_lbcs)
 
+      call mpas_get_time(nowTime, dateTimeString=xtime_new)
+      savepoint_name='minee'
+      CALL ser_init('init')
+      call fs_create_savepoint(TRIM(savepoint_name), ppser_savepoint)
+      call fs_add_savepoint_metainfo(ppser_savepoint, 'datetime', TRIM(xtime_new))
       if (trim(config_time_integration) == 'SRK3') then
          call atm_srk3(domain, dt, itimestep, exchange_halo_group)
       else
@@ -1865,13 +1876,39 @@ module atm_time_integration
       integer :: iCell, k, iq
       real (kind=RKIND) :: dtseps, c2, qtotal, rcv
       real (kind=RKIND), dimension( nVertLevels ) :: b_tri, c_tri
-
+      REAL(KIND=8), DIMENSION(5,5,5) :: av
 
       !  set coefficients
       dtseps = .5*dts*(1.+epssm)
       rcv = rgas/(cp-rgas)
       c2 = cp*rcv
 
+      av = 5.0
+
+      !CALL myserialize(av)
+      ! CALL ser_init('minee')
+      ! call fs_create_savepoint(TRIM(savepoint_name), ppser_savepoint)
+      ! call fs_add_savepoint_metainfo(ppser_savepoint, 'date', TRIM(date))
+
+
+      ! setup serialization environment
+      ! call ppser_initialize(directory='.',prefix='SerialboxTest')
+      ! call fs_create_savepoint('sp1', ppser_savepoint)
+      ! call ppser_set_mode(0)
+  
+      ! SELECT CASE ( ppser_get_mode() )
+      !   CASE(0)
+      !     call fs_write_field(ppser_serializer, ppser_savepoint, 'ser_a', qtotal)
+      !   CASE(1)
+      !     call fs_read_field(ppser_serializer_ref, ppser_savepoint, 'ser_a', qtotal)
+      !   CASE(2)
+      !     call fs_read_field(ppser_serializer_ref, ppser_savepoint, 'ser_a', qtotal, &
+      !                                                            ppser_zrperturb)
+      ! END SELECT
+
+      !CALL ser_array_d_3d('vara', scalars, 0)
+      !$acc enter data create(alpha_tri)
+      !CALL ser_array('alpha_tri', alpha_tri, 0)
 ! MGD bad to have all threads setting this variable?
       do k=1,nVertLevels
          cofrz(k) = dtseps*rdzw(k)
@@ -1933,6 +1970,9 @@ module atm_time_integration
          end do
 
       end do ! loop over cells
+      !$acc update device(alpha_tri)
+      CALL ser_array('alpha_tri', alpha_tri, 0)
+      !$acc exit data delete(alpha_tri)
 
    end subroutine atm_compute_vert_imp_coefs_work
 
@@ -3140,6 +3180,7 @@ module atm_time_integration
       !$acc enter data copyin(uhAvg, scalar_new)
       MPAS_ACC_TIMER_STOP('atm_advance_scalars [ACC_data_xfer]')
 
+      CALL ser_array('scalar_new', scalar_new, 0)
       !$acc parallel async
       !$acc loop gang worker private(scalar_weight2, ica)
       do iEdge=edgeStart,edgeEnd

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -2578,7 +2578,7 @@ module atm_time_integration
                                        cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
                                        cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
 
-      ! reconstitute state variables from acoustic-step perturbation variables 
+      ! reconstitute state variables from acoustic-step perturbation variables
       ! after the acoustic steps.  The perturbation variables were originally set in
       ! subroutine atm_set_smlstep_pert_variables prior to their acoustic-steps update.
       ! we are also computing a few other state-derived variables here.
@@ -2708,7 +2708,7 @@ module atm_time_integration
       real (kind=RKIND), intent(in) :: dt
 
       integer, dimension(nCells+1), intent(in) :: bdyMaskCell
-      
+
       real (kind=RKIND), dimension(nVertLevels+1,nCells+1) :: wwAvg
       real (kind=RKIND), dimension(nVertLevels+1,nCells+1) :: rw_save
       real (kind=RKIND), dimension(nVertLevels+1,nCells+1) :: w
@@ -2763,7 +2763,7 @@ module atm_time_integration
       rcv = rgas/(cp-rgas)
       p0 = 1.0e+05  ! this should come from somewhere else...
 
-      ! Avoid FP errors caused by a potential division by zero below by 
+      ! Avoid FP errors caused by a potential division by zero below by
       ! initializing the "garbage cell" of rho_zz to a non-zero value
       do k=1,nVertLevels
          rho_zz(k,nCells+1) = 1.0
@@ -2792,12 +2792,14 @@ module atm_time_integration
 
           ! pick up part of diagnosed w from omega - divide by density later
             w(k,iCell) = rw(k,iCell)/(fzm(k)*zz(k,iCell)+fzp(k)*zz(k-1,iCell))
-                                      
+
          end do
 
          w(nVertLevels+1,iCell) = 0.0
+      end do
 
-         if (rk_step == 3) then
+      if (rk_step == 3) then
+         do iCell=cellStart,cellEnd
 !DIR$ IVDEP
             do k = 1, nVertLevels
                rtheta_p(k,iCell) = rtheta_p_save(k,iCell) + rtheta_pp(k,iCell) &
@@ -2808,18 +2810,19 @@ module atm_time_integration
                pressure_p(k,iCell) = zz(k,iCell) * rgas * (exner(k,iCell)*rtheta_p(k,iCell)+rtheta_base(k,iCell)  &
                                                           * (exner(k,iCell)-exner_base(k,iCell)))
             end do
-         else
+         end do
+      else
+         do iCell=cellStart,cellEnd
 !DIR$ IVDEP
             do k = 1, nVertLevels
                rtheta_p(k,iCell) = rtheta_p_save(k,iCell) + rtheta_pp(k,iCell)
                theta_m(k,iCell) = (rtheta_p(k,iCell) + rtheta_base(k,iCell))/rho_zz(k,iCell)
             end do
-         end if
+         end do
+      end if
 
-      end do
-
-      ! recover time-averaged ruAvg on all edges of owned cells (for upcoming scalar transport).  
-      ! we solved for these in the acoustic-step loop.  
+      ! recover time-averaged ruAvg on all edges of owned cells (for upcoming scalar transport).
+      ! we solved for these in the acoustic-step loop.
       ! we will compute ru and u here also, given we are here, even though we only need them on nEdgesSolve
 
 !$OMP BARRIER
@@ -2847,29 +2850,29 @@ module atm_time_integration
 
          if (bdyMaskCell(iCell) <= nRelaxZone) then  ! addition for regional_MPAS, no spec zone update
 
-         do i=1,nEdgesOnCell(iCell)
-            iEdge=edgesOnCell(i,iCell)
+            do i=1,nEdgesOnCell(iCell)
+               iEdge=edgesOnCell(i,iCell)
 
-            flux = (cf1*ru(1,iEdge) + cf2*ru(2,iEdge) + cf3*ru(3,iEdge))
-            w(1,iCell) = w(1,iCell) + edgesOnCell_sign(i,iCell) * &
-                                   (zb_cell(1,i,iCell) + sign(1.0_RKIND,flux)*zb3_cell(1,i,iCell))*flux
+               flux = (cf1*ru(1,iEdge) + cf2*ru(2,iEdge) + cf3*ru(3,iEdge))
+               w(1,iCell) = w(1,iCell) + edgesOnCell_sign(i,iCell) * &
+                                      (zb_cell(1,i,iCell) + sign(1.0_RKIND,flux)*zb3_cell(1,i,iCell))*flux
 
 !DIR$ IVDEP
-            do k = 2, nVertLevels
-               flux = (fzm(k)*ru(k,iEdge)+fzp(k)*ru(k-1,iEdge))
-               w(k,iCell) = w(k,iCell) + edgesOnCell_sign(i,iCell) * &
-                                    (zb_cell(k,i,iCell)+sign(1.0_RKIND,flux)*zb3_cell(k,i,iCell))*flux
+               do k = 2, nVertLevels
+                  flux = (fzm(k)*ru(k,iEdge)+fzp(k)*ru(k-1,iEdge))
+                  w(k,iCell) = w(k,iCell) + edgesOnCell_sign(i,iCell) * &
+                                       (zb_cell(k,i,iCell)+sign(1.0_RKIND,flux)*zb3_cell(k,i,iCell))*flux
+               end do
+
             end do
 
-         end do
-
-         w(1,iCell) = w(1,iCell)/(cf1*rho_zz(1,iCell)+cf2*rho_zz(2,iCell)+cf3*rho_zz(3,iCell))
+            w(1,iCell) = w(1,iCell)/(cf1*rho_zz(1,iCell)+cf2*rho_zz(2,iCell)+cf3*rho_zz(3,iCell))
 
 
-         !DIR$ IVDEP
-         do k = 2, nVertLevels
-           w(k,iCell) = w(k,iCell)/(fzm(k)*rho_zz(k,iCell)+fzp(k)*rho_zz(k-1,iCell))
-         end do
+            !DIR$ IVDEP
+            do k = 2, nVertLevels
+              w(k,iCell) = w(k,iCell)/(fzm(k)*rho_zz(k,iCell)+fzp(k)*rho_zz(k-1,iCell))
+            end do
 
          end if ! addition for regional_MPAS, no spec zone update
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -16,6 +16,8 @@
 
 module atm_time_integration
    USE m_ser, ONLY: ser_init, ser_array
+   USE m_ser_mpas_cmp, ONLY: mpas_compare
+   USE m_ser_mpas, ONLY: mpas_set_serializer, mpas_set_savepoint
    USE m_serialize, ONLY: fs_add_savepoint_metainfo, fs_read_field, fs_create_savepoint, fs_write_field
    USE utils_ppser, ONLY: ppser_set_mode, ppser_initialize, ppser_get_mode, ppser_savepoint, &
        ppser_serializer, ppser_serializer_ref, ppser_intlength, ppser_reallength, &
@@ -481,7 +483,7 @@ module atm_time_integration
       call mpas_pool_get_config(block % configs, 'config_apply_lbcs', config_apply_lbcs)
 
       call mpas_get_time(nowTime, dateTimeString=xtime_new)
-      !$ser init directory='./ser_data' prefix='mpas_dycore'
+      !$ser init directory='./ser_data' prefix='mpas_dycore' prefix_ref='mpas_dycore-cpu'
       !$ser savepoint atm_srk3 datetime=xtime_new
       
       ! savepoint_name='minee'
@@ -2890,7 +2892,6 @@ module atm_time_integration
       integer, intent(in) :: cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd
       integer, intent(in) :: cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd
 
-
       !
       ! Local variables
       !
@@ -2972,12 +2973,24 @@ module atm_time_integration
             end do
          end do
          !$acc end parallel
-         ! !$ser spinfo rk_step=rk_step
+         
+         !$ser verbatim call fs_add_savepoint_metainfo(ppser_savepoint, 'rk_step', rk_step)
+         ! $ser mode read
+         ! $ser accdata rtheta_p=rtheta_p
+         ! $ser accdata theta_m=theta_m
+         ! $ser accdata exner=exner
+         ! $ser accdata pressure_p=pressure_p
+         !$ser compare theta_m rtol=1e-8 atol=1e-14
+         !CALL mpas_compare("theta_m", theta_m, cmp_result)
+         !call mpas_compare("theta_m",theta_m, rtol=1e-8, atol=1e-14)
+
          !$ser mode write
          !$ser accdata rtheta_p=rtheta_p
          !$ser accdata theta_m=theta_m
          !$ser accdata exner=exner
          !$ser accdata pressure_p=pressure_p
+         
+        
       else
          !$acc parallel
          !$acc loop collapse(2)

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -487,10 +487,6 @@ module atm_time_integration
       !$ser init directory='./ser_data' prefix='mpas_dycore' prefix_ref='mpas_dycore-cpu'
       !$ser savepoint atm_srk3 datetime=xtime_new
       
-      ! savepoint_name='minee'
-      ! CALL ser_init('init')
-      ! call fs_create_savepoint(TRIM(savepoint_name), ppser_savepoint)
-      ! call fs_add_savepoint_metainfo(ppser_savepoint, 'datetime', TRIM(xtime_new))
       if (trim(config_time_integration) == 'SRK3') then
          call atm_srk3(domain, dt, itimestep, exchange_halo_group)
       else
@@ -704,13 +700,6 @@ module atm_time_integration
       tend_rho_physics(:,nCells+1) = 0.0_RKIND
       call mpas_pool_get_array(tend_physics, 'tend_ru_physics', tend_ru_physics)
       tend_ru_physics(:,nEdges+1) = 0.0_RKIND
-
-
-
-      ! !$ser init directory='./ser_data' prefix='mpas_dycore'
-      ! !$ser savepoint atm_srk3 date=date rk_step=rk_step
-      ! !$ser mode write
-      ! !$ser accdata alpha_tri=alpha_tri
 
       !
       ! Initialize RK weights
@@ -1954,35 +1943,6 @@ module atm_time_integration
 
       av = 5.0
 
-      !CALL myserialize(av)
-      ! CALL ser_init('minee')
-      ! call fs_create_savepoint(TRIM(savepoint_name), ppser_savepoint)
-      ! call fs_add_savepoint_metainfo(ppser_savepoint, 'date', TRIM(date))
-
-
-      ! setup serialization environment
-      ! call ppser_initialize(directory='.',prefix='SerialboxTest')
-      ! call fs_create_savepoint('sp1', ppser_savepoint)
-      ! call ppser_set_mode(0)
-  
-      ! SELECT CASE ( ppser_get_mode() )
-      !   CASE(0)
-      !     call fs_write_field(ppser_serializer, ppser_savepoint, 'ser_a', qtotal)
-      !   CASE(1)
-      !     call fs_read_field(ppser_serializer_ref, ppser_savepoint, 'ser_a', qtotal)
-      !   CASE(2)
-      !     call fs_read_field(ppser_serializer_ref, ppser_savepoint, 'ser_a', qtotal, &
-      !                                                            ppser_zrperturb)
-      ! END SELECT
-
-      !CALL ser_array_d_3d('vara', scalars, 0)
-      !!$acc enter data create(alpha_tri)
-      !CALL ser_array('alpha_tri', alpha_tri, 0)
-
-      ! !$ser init directory='.' prefix='SerialboxTest'
-      ! !$ser savepoint sp1
-      ! !$ser mode write
-      ! !$ser accdata alpha_tri=alpha_tri
 ! MGD bad to have all threads setting this variable?
       do k=1,nVertLevels
          cofrz(k) = dtseps*rdzw(k)
@@ -2044,9 +2004,6 @@ module atm_time_integration
          end do
 
       end do ! loop over cells
-      !!$acc update device(alpha_tri)
-      !CALL ser_array('alpha_tri', alpha_tri, 0)
-      !!$acc exit data delete(alpha_tri)
 
    end subroutine atm_compute_vert_imp_coefs_work
 
@@ -2974,22 +2931,25 @@ module atm_time_integration
             end do
          end do
          !$acc end parallel
-         
-         !$ser verbatim call fs_add_savepoint_metainfo(ppser_savepoint, 'rk_step', rk_step)
-         ! $ser mode read
-         ! $ser accdata rtheta_p=rtheta_p
-         ! $ser accdata theta_m=theta_m
-         ! $ser accdata exner=exner
-         ! $ser accdata pressure_p=pressure_p
-         !$ser compare theta_m rtol=1e-8 atol=1e-14
-         !CALL mpas_compare("theta_m", theta_m, cmp_result)
-         !call mpas_compare("theta_m",theta_m, rtol=1e-8, atol=1e-14)
 
+         !$ser verbatim call fs_add_savepoint_metainfo(ppser_savepoint, 'rk_step', rk_step)
          !$ser mode write
          !$ser accdata rtheta_p=rtheta_p
-         !$ser accdata theta_m=theta_m
-         !$ser accdata exner=exner
-         !$ser accdata pressure_p=pressure_p
+
+
+         !!$ser verbatim call fs_add_savepoint_metainfo(ppser_savepoint, 'rk_step', rk_step)
+         !!$ser mode read
+         !!$ser accdata rtheta_p=rtheta_p
+         !!$ser accdata theta_m=theta_m
+         !!$ser accdata exner=exner
+         !!$ser accdata pressure_p=pressure_p
+         !!!$ser compare theta_m rtol=1e-8 atol=1e-14
+
+         !!$ser mode write
+         !!$ser accdata rtheta_p=rtheta_p
+         !!$ser accdata theta_m=theta_m
+         !!$ser accdata exner=exner
+         !!$ser accdata pressure_p=pressure_p
          
         
       else


### PR DESCRIPTION
Steps to use the python scripts for comparison

1. Load the modules
```
1) ncarenv/23.09 (S)   2) craype/2.7.23   3) nvhpc/24.3   4) ncarcompilers/1.0.0   5) cray-mpich/8.1.27   6) parallel-netcdf/1.12.3   7) cuda/12.2.1
```
2. Activate python env and set some paths
```
export SERIALBOX_ROOT=/glade/derecho/scratch/agopal/serialbox_2.6.2_2
source $SERIALBOX_ROOT/.venv/bin/activate

export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SERIALBOX_ROOT/install/lib:/glade/u/apps/common/23.08/spack/opt/spack/gcc/13.2.0/lib64

export PYTHONPATH=$SERIALBOX_ROOT/install/python:$PYTHONPATH
```

3. Run compare script
```
python $SERIALBOX_ROOT/src/serialbox-python/compare/compare.py dir1/ser_data/MetaData-mpas_dycore.json dir2/ser_data/MetaData-mpas_dycore.json
```


link to hackmd page with more info: https://hackmd.io/uT-W_PEhTSWXZI7YkS0wWA